### PR TITLE
Bourbon button fixes

### DIFF
--- a/app/assets/stylesheets/alchemy/_mixins.scss
+++ b/app/assets/stylesheets/alchemy/_mixins.scss
@@ -1,6 +1,6 @@
 @mixin default-focus-style {
   border-color: $blue;
-  box-shadow: 0 0 1px 2px $blue;
+  box-shadow: 0 0 1px 1px $blue;
   outline: none;
 
   &::-moz-focus-inner {

--- a/app/assets/stylesheets/alchemy/_mixins.scss
+++ b/app/assets/stylesheets/alchemy/_mixins.scss
@@ -9,16 +9,52 @@
   }
 }
 
-@mixin button-defaults {
-  @include button($base-color: $white, $padding: 0.5em 1.5em);
+@mixin button-defaults($padding: $button-padding, $margin: $button-margin) {
+  display: inline-block;
+  font-size: 12px;
+  padding: $padding;
+  cursor: pointer;
+  border-radius: $default-border-radius;
   background-color: $button-bg-color;
-  border-color: $button-border-color;
-  font-weight: normal;
-  text-color: $text-color;
+  background-image: linear-gradient($button-gradient-first-color, $button-gradient-second-color);
+  box-shadow: white 0 1px 0 inset;
+  border: 1px solid $button-border-color;
+  color: $text-color;
   text-shadow: $button-text-shadow;
+  margin: $margin;
+  @include appearance(none);
+
   &:hover {
+    text-decoration: none;
     background-color: $button-hover-bg-color;
+    background-image: linear-gradient(
+      darken($button-gradient-first-color, 5%),
+      darken($button-gradient-second-color, 5%)
+    );
     border-color: $button-hover-border-color;
+  }
+
+  &:active, &:active:focus {
+    box-shadow: #c4c4c4 0 1px 2px inset;
+    border-color: $button-border-color;
+  }
+
+  &:focus {
+    @include default-focus-style;
+  }
+
+  &.disabled, &[disabled],
+  &.disabled:active, &[disabled]:active,
+  &.disabled:hover, &[disabled]:hover {
+    opacity: 0.6;
+    background: $button-gradient-second-color;
+    cursor: not-allowed;
+    box-shadow: none;
+  }
+
+  &::-moz-focus-inner {
+    padding: 0 !important;
+    margin: -1px !important;
   }
 }
 

--- a/app/assets/stylesheets/alchemy/_variables.scss
+++ b/app/assets/stylesheets/alchemy/_variables.scss
@@ -27,15 +27,18 @@ $default-border-width: 1px;
 $default-border-style: solid;
 $default-border: $default-border-width $default-border-style $default-border-color;
 $default-border-radius: 3px;
+$default-form-field-margin: $default-margin 0;
 
 $button-bg-color: #f7f7f7;
 $button-hover-bg-color: #e6f0f5;
 $button-border-color: #9a9a9a;
 $button-hover-border-color: #888888;
 $button-text-shadow: $white 1px 1px 0;
+$button-gradient-first-color: $white !default;
+$button-gradient-second-color: darken($button-gradient-first-color, 10%) !default;
+$button-padding: 0.5em 1.5em !default;
+$button-margin: $default-form-field-margin !default;
 $linked-button-color: #ffd77a;
-
-$default-form-field-margin: $default-padding 0;
 
 $success_border_color: #9cc4a1;
 $success_text_color: #2e5934;

--- a/app/assets/stylesheets/alchemy/buttons.scss
+++ b/app/assets/stylesheets/alchemy/buttons.scss
@@ -35,15 +35,9 @@ button, input[type="submit"], a.button, input.button {
     }
   }
 
-  &:focus {
-    @extend %blue-focus-style;
-  }
-
   &.disabled {
     line-height: 13px;
     height: 29px;
-    padding-top: 5px;
-    padding-bottom: 4px;
   }
 }
 

--- a/app/assets/stylesheets/alchemy/selects.scss
+++ b/app/assets/stylesheets/alchemy/selects.scss
@@ -3,6 +3,7 @@ select {
   height: 29px;
   padding: 0.4em 0.6em;
   max-width: 100%;
+  width: auto;
 }
 
 .select2-container {
@@ -14,10 +15,9 @@ select {
     .select2-choice {
       height: 27px;
       line-height: 27px;
-      @include button($base-color: $white, $padding: 0 5px);
+      @include button-defaults($padding: 0 2*$default-padding, $margin: 0);
       display: block;
       font-weight: normal;
-      border-color: $button-border-color;
       text-align: left;
 
       .select2-arrow {
@@ -53,6 +53,7 @@ select {
       .select2-choice {
         height: 18px;
         line-height: 18px;
+        padding-right: 0;
 
         .select2-arrow {
           width: 14px;

--- a/app/assets/stylesheets/tinymce/skins/alchemy/skin.min.css.scss
+++ b/app/assets/stylesheets/tinymce/skins/alchemy/skin.min.css.scss
@@ -28,7 +28,6 @@
 
 .mce-widget button {
   box-sizing: border-box;
-  @include button($base-color: $white, $padding: none);
 }
 
 .mce-container *[unselectable] {
@@ -619,11 +618,15 @@ body .mce-abs-layout-item,.mce-abs-end {
   *display: inline;
   *zoom: 1;
   box-shadow: inset 0 1px 0 rgba(255,255,255,0.2),0 1px 2px rgba(0,0,0,0.05);
-  @include background(linear-gradient(color-stops($white, darken($white, 10%))));
+  @include background(linear-gradient($button-gradient-first-color, $button-gradient-second-color));
 
   &:hover, &:focus {
     color: #333;
-    @include background(linear-gradient(color-stops(darken($white, 10%), darken($white, 20%))));
+
+    @include background(linear-gradient(
+      darken($button-gradient-first-color, 5%),
+      darken($button-gradient-second-color, 5%)
+    ));
 
     button {
       @include background(inherit);
@@ -646,6 +649,10 @@ body .mce-abs-layout-item,.mce-abs-end {
       box-shadow: none;
       border: 0 none;
       background: none;
+    }
+
+    &:active {
+      border: 0 none;
     }
 
     &::-moz-focus-inner {


### PR DESCRIPTION
In contrary to my comment in https://github.com/AlchemyCMS/alchemy_cms/pull/1052, we decided to ditch the bourbon button mixin after all. 

Sorry for the inconvenience, but the default bourbon button style was not fitting Alchemy UI and was hard to override.

In order to not burden you with even more work, I made this PR to support your work!

It also contains fixes for the Tinymce skin I mentioned in my comment on https://github.com/AlchemyCMS/alchemy_cms/pull/1052.

Thanks again for all the effort 🍨 
